### PR TITLE
allow extra opts arg in reagent.core/adapt-react-class

### DIFF
--- a/src/reagent/core.cljs
+++ b/src/reagent/core.cljs
@@ -48,9 +48,9 @@
 (defn adapt-react-class
   "Returns an adapter for a native React class, that may be used
   just like a Reagent component function or class in Hiccup forms."
-  [c]
+  [c & [opts]]
   (assert c)
-  (tmpl/adapt-react-class c))
+  (tmpl/adapt-react-class c opts))
 
 (defn reactify-component
   "Returns an adapter for a Reagent component, that may be used from

--- a/src/reagent/impl/template.cljs
+++ b/src/reagent/impl/template.cljs
@@ -242,7 +242,7 @@
   ([{:keys [synthetic-input?]}]
    (if synthetic-input?
      (do
-       (when (nil? reagent-input-class)
+       (when (nil? reagent-synthetic-input-class)
          (set! reagent-synthetic-input-class (comp/create-class synthetic-input-spec)))
        reagent-synthetic-input-class)
      (do


### PR DESCRIPTION
While I realize this is a proof-of-concept, I guess people who want to try it may have trouble realizing that they need use `reagent.impl.template/adapt-react-class` instead of the `reagent.core` name.